### PR TITLE
Enable onboard EEPROM

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
@@ -38,6 +38,14 @@
 #define DISABLE_JTAG
 
 //
+// EEPROM
+//
+#if NO_EEPROM_SELECTED
+  #define I2C_EEPROM                             // AT24Cxx
+  #define MARLIN_EEPROM_SIZE              0x800  // 2K (24C16)
+#endif
+
+//
 // Limit Switches
 //
 #define X_STOP_PIN                          PC13


### PR DESCRIPTION
Addresses #5, where using the printer directly without an SD card fails due to SD EEPROM emulation being used.
This replicates the default vendor configuration.
