### PR TITLE
GitHub Actions workflow to auto-compile mksLite.bin on every push

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,30 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run -e mks_robin_lite_maple
+
+      - name: Upload compiled binary
+        uses: actions/upload-artifact@v4
+        with:
+          path: .pio/build/mks_robin_lite_maple/mksLite.bin
+          name: mksLite.bin


### PR DESCRIPTION
Uses platformio "template", builds on every push, builds using `mks_robin_lite_maple` env, uploads the built binary as artifact which can be downloaded. I suggest adding this to other branches (by cherry-picking) as well, especially those related to K9 version.